### PR TITLE
Convert vignette to use caching

### DIFF
--- a/.github/workflows/check-and-test.yml
+++ b/.github/workflows/check-and-test.yml
@@ -1,0 +1,73 @@
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+name: "check, test, and coverage"
+
+jobs:
+  test-coverage:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - name: Query dependencies
+        run: |
+          install.packages(c('covr','remotes','sessioninfo'))
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes"))
+          install.packages("BiocManager")
+          remotes::install_deps(dependencies = TRUE, repos = BiocManager::repositories())
+          remotes::install_cran("covr")
+        shell: Rscript {0}
+
+      - name: Session info
+        run: |
+          options(width = 100)
+          pkgs <- installed.packages()[, "Package"]
+          sessioninfo::session_info(pkgs, include_base = TRUE)
+        shell: Rscript {0}
+
+      - name: Check
+        env:
+          _R_CHECK_CRAN_INCOMING_: false
+        run: rcmdcheck::rcmdcheck(args = c("--no-manual"), error_on = "error", check_dir = "check")
+        shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check
+
+      - name: Test coverage
+        run: covr::codecov()
+        shell: Rscript {0}

--- a/vignettes/GenomicSuperSignature_Contents.Rmd
+++ b/vignettes/GenomicSuperSignature_Contents.Rmd
@@ -43,15 +43,13 @@ There are two versions of this using different gene sets for GSEA-based annotati
 MSigDB C2 (`C2`) and three priors from PLIER package (`PLIERpriors`). In this 
 vignette, we are using the `C2` annotated model.
 
-```{r load_model, eval=FALSE}
-if (!file.exists("RAVmodel_C2.rds")) {getModel("C2")} 
-RAVmodel <- readRDS("RAVmodel_C2.rds")
-RAVmodel
-```
+Note that the first interactive run of this code, you will be asked to allow
+R to create a cache directory. The model file will be stored there and subsequent
+calls to `getModel` will read from the cache.
 
-```{r echo=FALSE}
-RAVmodel <- readRDS("RAVmodel_C2.rds")
-RAVmodel
+
+```{r load_model, eval=FALSE}
+RAVmodel <- getModel("C2", load=TRUE)
 ```
 
 

--- a/vignettes/Quickstart.Rmd
+++ b/vignettes/Quickstart.Rmd
@@ -43,17 +43,13 @@ There are two versions of this using different gene sets for GSEA-based annotati
 MSigDB C2 (`C2`) and three priors from PLIER package (`PLIERpriors`). In this 
 vignette, we are using the `C2` annotated model.
 
-```{r load_model, eval=FALSE}
-if (!file.exists("RAVmodel_C2.rds")) {getModel("C2")} 
-RAVmodel <- readRDS("RAVmodel_C2.rds")
-RAVmodel
-```
+Note that the first interactive run of this code, you will be asked to allow
+R to create a cache directory. The model file will be stored there and subsequent
+calls to `getModel` will read from the cache.
 
-```{r echo=FALSE}
-RAVmodel <- readRDS("RAVmodel_C2.rds")
-RAVmodel
+```{r load_model}
+RAVmodel <- getModel("C2", load=TRUE)
 ```
-
 
 ## Example dataset
 **Human B-cell expression dataset** The human B-cell dataset (Gene Expression Omnibus series GSE2350) 
@@ -152,9 +148,7 @@ Because the test dataset is human B-cell expression data, we tried the model ann
 with blood-associated gene sets. 
 
 ```{r message=FALSE, warning=FALSE}
-if (!file.exists("RAVmodel_PLIERpriors.rds")) {getModel("PLIERpriors")} 
-RAVmodel <- readRDS("RAVmodel_PLIERpriors.rds")
-RAVmodel
+RAVmodel <- getModel("PLIERpriors", load=TRUE)
 ```
 
 You can directly access the GSEA outputs for each RAV using the accessor, `gsea`.


### PR DESCRIPTION
Rather than a readRDS call, use the
getModel function directly.
